### PR TITLE
decouple MITRE mapping from agent_framework and Azure

### DIFF
--- a/agents/scanner/pipeline/mitre_mapper.py
+++ b/agents/scanner/pipeline/mitre_mapper.py
@@ -1,14 +1,18 @@
 """
 Scanner Pipeline - MITRE ATT&CK Mapper
-Analyzes findings using MITRE ATT&CK framework with multi-agent concurrent approach.
-Creates one agent per finding to map to MITRE techniques and adjust severity.
 
-NOTE: This module is currently Azure-only. It uses `AzureOpenAIChatClient`
-directly because the MITRE lookup runs through `MCPStreamableHTTPTool`
-(agent_framework's MCP client), which is not wired through the
-provider-agnostic `LLMProvider` interface yet. Claude MCP support is tracked
-separately (see Issue #4: Scanner Revamp with Claude CLI / specialized tools).
-If `LLM_PROVIDER=claude`, callers should skip MITRE mapping or use a fallback.
+Maps deduplicated security findings to MITRE ATT&CK techniques using a
+provider-agnostic design:
+
+  1. One MCP call at start to cache every Enterprise technique in memory.
+  2. Per finding: Python shortlists the top-k candidates by token overlap.
+  3. One `provider.structured_output(...)` call asks the LLM to pick the best
+     match and adjust severity. No tool-use loop, no per-provider branches.
+
+This module no longer depends on `agent_framework`; it uses the public `mcp`
+SDK for MCP I/O (via `shared.mcp_utils`) and the `LLMProvider` abstraction for
+reasoning, so it works identically under `LLM_PROVIDER=azure` and
+`LLM_PROVIDER=claude`.
 """
 
 import os
@@ -16,176 +20,262 @@ import re
 import json
 import asyncio
 from datetime import datetime
-from typing import Annotated
+from typing import Annotated, Any, Dict, List, Optional
+
 from pydantic import Field
 
-from agent_framework.azure import AzureOpenAIChatClient
-from agent_framework._mcp import MCPStreamableHTTPTool
-
-from shared.base_agent import get_azure_api_key, get_azure_endpoint, get_deployment_name
+from shared.llm_provider import get_provider
+from shared.mcp_utils import mcp_session, call_tool_json
 from shared.s3_helpers import download_json_from_s3, upload_json_to_s3
+
+
+MITRE_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "technique_id":      {"type": "string"},
+        "technique_name":    {"type": "string"},
+        "tactic":            {"type": "string"},
+        "adjusted_severity": {"type": "string", "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW"]},
+        "confidence":        {"type": "string", "enum": ["HIGH", "MEDIUM", "LOW"]},
+        "rationale":         {"type": "string"},
+    },
+    "required": [
+        "technique_id",
+        "technique_name",
+        "tactic",
+        "adjusted_severity",
+        "confidence",
+        "rationale",
+    ],
+    "additionalProperties": False,
+}
+
+
+SYSTEM_PROMPT = """You are an expert security analyst specializing in the MITRE ATT&CK framework.
+For each finding, pick the single best-matching ATT&CK technique from the candidate list
+provided in the user message and adjust severity based on the tactic it belongs to.
+
+You MUST return a single JSON object with EXACTLY these six keys, ALL required:
+  - technique_id      (string, MITRE T#### or T####.### from the candidate list)
+  - technique_name    (string, the `name` field of the candidate you picked)
+  - tactic            (string, e.g. "Credential Access", "Initial Access")
+  - adjusted_severity (one of: "CRITICAL", "HIGH", "MEDIUM", "LOW")
+  - confidence        (one of: "HIGH", "MEDIUM", "LOW")
+  - rationale         (string, one or two sentences explaining the match)
+
+Never omit a key. Never wrap the JSON in prose or code fences.
+
+Severity mapping by tactic:
+  CRITICAL: Privilege Escalation, Credential Access, Initial Access, Execution
+  HIGH:     Lateral Movement, Persistence, Impact, Defense Evasion
+  MEDIUM:   Discovery, Collection, Command and Control
+  LOW:      Informational findings only
+
+If no candidate fits, return the single closest match and set `confidence` to LOW with a
+rationale explaining why."""
+
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9]+")
+_STOPWORDS = {
+    "the", "a", "an", "and", "or", "but", "of", "in", "on", "to", "for",
+    "with", "is", "are", "was", "were", "be", "been", "by", "at", "from",
+    "this", "that", "these", "those", "it", "its", "as", "if", "not",
+}
+
+
+def _tokenize(text: str) -> List[str]:
+    return [t for t in (m.group(0).lower() for m in _TOKEN_RE.finditer(text or ""))
+            if t not in _STOPWORDS and len(t) > 2]
+
+
+def shortlist_techniques(
+    finding: Dict[str, Any],
+    techniques: List[Dict[str, Any]],
+    k: int = 40,
+) -> List[Dict[str, Any]]:
+    """Rank `techniques` by token-overlap against the finding's text fields and
+    return the top `k`. Deterministic and dependency-free so tests don't need
+    a real LLM or MCP server.
+
+    Each returned technique is the original dict filtered to the fields the
+    prompt needs: `mitre_id`, `name`, `description` (truncated).
+    """
+    if not techniques:
+        return []
+
+    finding_text = " ".join([
+        str(finding.get("finding_title", "")),
+        str(finding.get("description", "")),
+        str(finding.get("scan_type", "")),
+        str(finding.get("resource_type", "")),
+        str(finding.get("file_path", "")),
+    ])
+    finding_tokens = set(_tokenize(finding_text))
+    if not finding_tokens:
+        return [_compact(t) for t in techniques[:k]]
+
+    scored: List[tuple] = []
+    for tech in techniques:
+        if not tech.get("mitre_id"):
+            continue
+        tech_text = f"{tech.get('name', '')} {tech.get('description', '')}"
+        tech_tokens = set(_tokenize(tech_text))
+        if not tech_tokens:
+            continue
+        score = len(finding_tokens & tech_tokens)
+        if score > 0:
+            scored.append((score, tech))
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [_compact(t) for _, t in scored[:k]]
+
+
+def _compact(tech: Dict[str, Any]) -> Dict[str, Any]:
+    """Strip a technique dict down to what the LLM prompt needs."""
+    desc = tech.get("description") or ""
+    if len(desc) > 300:
+        desc = desc[:297] + "..."
+    return {
+        "technique_id": tech.get("mitre_id", ""),
+        "name": tech.get("name", ""),
+        "description": desc,
+    }
+
+
+async def _load_technique_cache(session) -> List[Dict[str, Any]]:
+    """Fetch all Enterprise techniques once, with descriptions, from the MCP
+    server. Paginates until `has_more` is false so we don't silently truncate
+    at the server's default page size (Montimage mitre-mcp caps at 20).
+    Returns an empty list on failure so the pipeline degrades gracefully
+    (the LLM can still attempt a mapping from training data)."""
+    all_techniques: List[Dict[str, Any]] = []
+    offset = 0
+    page_size = 500
+
+    try:
+        while True:
+            payload = await call_tool_json(
+                session,
+                "get_techniques",
+                {
+                    "domain": "enterprise-attack",
+                    "include_descriptions": True,
+                    "limit": page_size,
+                    "offset": offset,
+                },
+            )
+            if isinstance(payload, list):
+                all_techniques.extend(payload)
+                break
+            if not isinstance(payload, dict):
+                print(f"[MITRE] Unexpected get_techniques payload shape: {type(payload).__name__}")
+                break
+            page = payload.get("techniques") or []
+            all_techniques.extend(page)
+            pagination = payload.get("pagination") or {}
+            if not pagination.get("has_more") or not page:
+                break
+            offset += len(page)
+            if offset > 10000:  # runaway safeguard
+                print(f"[MITRE] Pagination guard tripped at offset={offset}; stopping.")
+                break
+    except Exception as e:
+        print(f"[MITRE] Failed to load technique cache at offset={offset}: {e}. Returning {len(all_techniques)} techniques loaded so far.")
+
+    return all_techniques
+
+
+def _build_prompt(finding_id: str, finding: Dict[str, Any], candidates: List[Dict[str, Any]]) -> str:
+    fields = {
+        "finding_id":    finding_id,
+        "tool":          finding.get("tool_name", finding.get("tool", "unknown")),
+        "scan_type":     finding.get("scan_type", "N/A"),
+        "file_path":     finding.get("file_path", "N/A"),
+        "resource_type": finding.get("resource_type", "N/A"),
+        "title":         finding.get("finding_title", finding.get("title", "N/A")),
+        "description":   finding.get("description", "N/A"),
+        "severity":      finding.get("severity", "UNKNOWN"),
+    }
+    return (
+        "Finding:\n"
+        + json.dumps(fields, indent=2)
+        + "\n\nCandidate MITRE ATT&CK techniques (pick exactly one `technique_id` from this list):\n"
+        + json.dumps(candidates, indent=2)
+        + "\n\nReturn a single JSON object with exactly these keys: "
+          "technique_id, technique_name, tactic, adjusted_severity, confidence, rationale. "
+          "All six are required."
+    )
 
 
 async def analyze_findings_with_mitre(
     s3_location: Annotated[str, Field(description="S3 location (s3://bucket/key) of deduplicated findings")],
 ) -> str:
     """
-    Analyze security findings using MITRE ATT&CK framework with multi-agent approach.
+    Analyze security findings by mapping each to a MITRE ATT&CK technique.
 
-    Creates one agent per finding to map to MITRE techniques and adjust severity.
-    Uses concurrent execution with rate limiting (max 15 parallel agents).
+    Runs concurrently (15 parallel workers) but issues exactly one LLM call per
+    finding, grounded in a technique list fetched once from the MITRE MCP
+    server at `MITRE_MCP_URL` (default `http://mitre-mcp:8000/mcp`).
 
-    The MITRE MCP server URL is read from the MITRE_MCP_URL env var. Not exposed
-    as a tool argument because LLMs tend to hallucinate plausible-looking URLs
-    (e.g. `https://mitre-mcp.example.com`) when they see an optional parameter.
+    The URL is read from an env var rather than a tool parameter because LLMs
+    tend to hallucinate plausible-looking URLs when they see an optional arg.
     """
     mitre_mcp_url = os.environ.get("MITRE_MCP_URL", "http://mitre-mcp:8000/mcp")
-    print(f"[MITRE] Starting multi-agent analysis for findings from {s3_location}")
+    print(f"[MITRE] Starting analysis for findings from {s3_location}")
 
     try:
         findings_data = download_json_from_s3(s3_location)
     except Exception as e:
         return f"Error downloading findings from S3: {e}"
 
-    findings = findings_data.get('findings', [])
+    findings: List[Dict[str, Any]] = findings_data.get("findings", [])
     total_findings = len(findings)
-
-    print(f"[MITRE] Downloaded {total_findings} findings for analysis")
+    print(f"[MITRE] Downloaded {total_findings} findings")
     if total_findings == 0:
         return "No findings to analyze"
 
-    chat_client = AzureOpenAIChatClient(
-        endpoint=get_azure_endpoint(),
-        api_key=get_azure_api_key(),
-        model=get_deployment_name()
-    )
+    provider = get_provider()
 
     print(f"[MITRE] Connecting to MCP server at {mitre_mcp_url}")
-
-    async with MCPStreamableHTTPTool(name="mitre_attack", url=mitre_mcp_url) as mcp_tool:
-        print(f"[MITRE] MCP connected. Creating {total_findings} agents...")
+    async with mcp_session(mitre_mcp_url) as session:
+        print("[MITRE] MCP connected. Loading technique cache...")
+        technique_cache = await _load_technique_cache(session)
+        print(f"[MITRE] Cached {len(technique_cache)} techniques. Starting {total_findings} concurrent analyses...")
 
         semaphore = asyncio.Semaphore(15)
-
         tool_prefixes = {
-            'trivy-iac': 'TI', 'trivy-sca': 'TS', 'trivy-secret': 'TX',
-            'trivy-image': 'TG', 'checkov': 'C', 'bandit': 'B',
-            'semgrep': 'S', 'unknown': 'U'
+            "trivy-iac": "TI", "trivy-sca": "TS", "trivy-secret": "TX",
+            "trivy-image": "TG", "checkov": "C", "bandit": "B",
+            "semgrep": "S", "unknown": "U",
         }
-        tool_counts = {}
+        tool_counts: Dict[str, int] = {}
+        id_lock = asyncio.Lock()
 
-        async def analyze_single_finding(finding: dict, index: int) -> dict:
+        async def analyze_one(finding: Dict[str, Any], index: int) -> Dict[str, Any]:
             async with semaphore:
-                try:
-                    tool_name = finding.get('tool_name', finding.get('tool', 'unknown')).lower()
-                    prefix = tool_prefixes.get(tool_name, 'U')
-
-                    if prefix not in tool_counts:
-                        tool_counts[prefix] = 0
-                    tool_counts[prefix] += 1
-
+                tool_name = str(finding.get("tool_name", finding.get("tool", "unknown"))).lower()
+                prefix = tool_prefixes.get(tool_name, "U")
+                async with id_lock:
+                    tool_counts[prefix] = tool_counts.get(prefix, 0) + 1
                     finding_id = f"FND-{prefix}-{tool_counts[prefix]}"
 
-                    title = finding.get('finding_title', finding.get('title', 'N/A'))
-                    description = finding.get('description', 'N/A')
-                    severity = finding.get('severity', 'UNKNOWN')
-                    file_path = finding.get('file_path', 'N/A')
-                    resource_type = finding.get('resource_type', 'N/A')
-                    scan_type = finding.get('scan_type', 'N/A')
+                try:
+                    candidates = shortlist_techniques(finding, technique_cache, k=40)
+                    prompt = _build_prompt(finding_id, finding, candidates)
 
-                    print(f"[MITRE] Agent {index + 1}/{total_findings}: Analyzing {finding_id}")
-
-                    instructions = f"""You are an expert security analyst specializing in MITRE ATT&CK framework.
-
-**Finding to Analyze:**
-- Finding ID: {finding_id}
-- Tool: {tool_name}
-- File: {file_path}
-- Resource Type: {resource_type}
-- Title: {title}
-- Description: {description}
-- Scan Type: {scan_type}
-- Original Severity: {severity}
-
-**Steps:**
-1. Extract the threat behavior from this finding
-2. USE MITRE ATT&CK tools to search for matching techniques
-3. Map to a MITRE technique (T#### format)
-4. Adjust severity based on MITRE tactic context:
-   - CRITICAL: Privilege Escalation, Credential Access, Initial Access, Execution
-   - HIGH: Lateral Movement, Persistence, Impact, Defense Evasion
-   - MEDIUM: Discovery, Collection, Command and Control
-   - LOW: Informational findings
-
-Return ONLY valid JSON:
-{{"technique_id": "T####", "technique_name": "...", "tactic": "...", "adjusted_severity": "CRITICAL|HIGH|MEDIUM|LOW", "confidence": "HIGH|MEDIUM|LOW", "rationale": "..."}}"""
-
-                    agent = chat_client.create_agent(
-                        name=f"ThreatAnalyst_{finding_id}",
-                        instructions=instructions,
-                        tools=[mcp_tool]
+                    mitre_data = await provider.structured_output(
+                        schema=MITRE_SCHEMA,
+                        prompt=prompt,
+                        system=SYSTEM_PROMPT,
+                        temperature=0.0,
+                        max_tokens=800,
                     )
-                    result = await agent.run(f"Analyze finding {finding_id} and map to MITRE ATT&CK")
 
-                    analysis_text = str(result.text) if hasattr(result, 'text') else str(result)
-
-                    mitre_data = {
-                        "technique_id": "UNMAPPED",
-                        "technique_name": "Unable to map",
-                        "tactic": "Unknown",
-                        "adjusted_severity": severity,
-                        "confidence": "LOW",
-                        "rationale": analysis_text[:500]
-                    }
-
-                    # Strategy 1: parse full text as JSON directly
-                    _parsed = None
-                    try:
-                        _parsed = json.loads(analysis_text)
-                    except (json.JSONDecodeError, ValueError):
-                        pass
-
-                    # Strategy 2: find outermost balanced {...} block containing technique_id
-                    if _parsed is None and '"technique_id"' in analysis_text:
-                        for _start in range(len(analysis_text)):
-                            if analysis_text[_start] != '{':
-                                continue
-                            _depth = 0
-                            for _end in range(_start, len(analysis_text)):
-                                if analysis_text[_end] == '{':
-                                    _depth += 1
-                                elif analysis_text[_end] == '}':
-                                    _depth -= 1
-                                    if _depth == 0:
-                                        try:
-                                            candidate = json.loads(analysis_text[_start:_end + 1])
-                                            if 'technique_id' in candidate:
-                                                _parsed = candidate
-                                        except (json.JSONDecodeError, ValueError):
-                                            pass
-                                        break
-                            if _parsed is not None:
-                                break
-
-                    if _parsed is not None:
-                        mitre_data.update(_parsed)
-                    else:
-                        # Strategy 3: regex fallback — recover bare technique ID only
-                        tid_match = re.search(r'T\d{4}(?:\.\d{3})?', analysis_text)
-                        if tid_match:
-                            mitre_data['technique_id'] = tid_match.group(0)
-
-                    print(f"[MITRE] Agent {index + 1}/{total_findings}: {finding_id} -> {mitre_data['technique_id']}")
-
-                    return {
-                        finding_id: {
-                            "finding": finding,
-                            "mitre_analysis": mitre_data
-                        }
-                    }
+                    print(f"[MITRE] {index + 1}/{total_findings}: {finding_id} -> {mitre_data.get('technique_id', 'UNMAPPED')}")
+                    return {finding_id: {"finding": finding, "mitre_analysis": mitre_data}}
 
                 except Exception as e:
-                    print(f"[MITRE] Agent {index + 1}/{total_findings}: Error: {e}")
+                    print(f"[MITRE] {index + 1}/{total_findings}: error for {finding_id}: {e}")
                     return {
                         f"FND-ERR-{index}": {
                             "finding": finding,
@@ -195,37 +285,28 @@ Return ONLY valid JSON:
                                 "tactic": "N/A",
                                 "adjusted_severity": "UNKNOWN",
                                 "confidence": "NONE",
-                                "rationale": f"Error: {str(e)}"
-                            }
+                                "rationale": f"Error: {e}",
+                            },
                         }
                     }
 
-        print(f"[MITRE] Starting concurrent analysis (max 15 parallel)...")
-        results = await asyncio.gather(*(
-            analyze_single_finding(finding, idx)
-            for idx, finding in enumerate(findings)
-        ))
+        results = await asyncio.gather(*(analyze_one(f, i) for i, f in enumerate(findings)))
 
-        print(f"[MITRE] All agents completed. Processing results...")
-
-        mitre_mapped = {
-            "metadata": {
-                "analysis_date": datetime.utcnow().isoformat(),
-                "total_findings": total_findings,
-                "mitre_mcp_url": mitre_mcp_url,
-                "source_file": s3_location,
-                "tool_distribution": dict(tool_counts)
-            }
+    mitre_mapped: Dict[str, Any] = {
+        "metadata": {
+            "analysis_date": datetime.utcnow().isoformat(),
+            "total_findings": total_findings,
+            "mitre_mcp_url": mitre_mcp_url,
+            "source_file": s3_location,
+            "tool_distribution": dict(tool_counts),
+            "technique_cache_size": len(technique_cache),
         }
+    }
+    for r in results:
+        mitre_mapped.update(r)
 
-        for result in results:
-            mitre_mapped.update(result)
-
-        s3_loc = upload_json_to_s3(mitre_mapped, "mitre-mapped-findings")
-
-        mapped_count = sum(1 for r in results if not any('ERR' in k for k in r.keys()))
-        error_count = sum(1 for r in results if any('ERR' in k for k in r.keys()))
-        print(f"[MITRE] Complete: {mapped_count} mapped, {error_count} errors")
-        print(f"[MITRE] Uploaded to {s3_loc}")
-
-        return s3_loc
+    s3_loc = upload_json_to_s3(mitre_mapped, "mitre-mapped-findings")
+    mapped = sum(1 for r in results if not any("ERR" in k for k in r.keys()))
+    errors = total_findings - mapped
+    print(f"[MITRE] Complete: {mapped} mapped, {errors} errors. Uploaded to {s3_loc}")
+    return s3_loc

--- a/shared/mcp_utils.py
+++ b/shared/mcp_utils.py
@@ -1,0 +1,66 @@
+"""
+Async helpers for talking to MCP servers over streamable HTTP.
+
+Wraps the public `mcp` SDK so callers don't repeat the two-level context-manager
+dance or the text-block JSON decoding. Use `mcp_session(url)` to get an
+initialized `ClientSession`; use `call_tool_json(session, name, args)` to invoke
+a tool and get back parsed JSON.
+
+The MITRE MCP server (Montimage/mitre-mcp) returns tool results as a single
+text block containing a JSON-encoded payload; newer servers may also populate
+`structuredContent`. Both are handled here.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from typing import Any, Dict, Optional
+
+
+@asynccontextmanager
+async def mcp_session(url: str):
+    """Yield an initialized `ClientSession` bound to the MCP server at `url`.
+
+    The `streamablehttp_client` context manager yields a 3-tuple
+    (read_stream, write_stream, get_session_id_callback); we discard the third
+    because MITRE mapping does not need resumable session IDs.
+
+    `mcp` is imported lazily so test environments that only exercise the
+    `call_tool_json` parser don't need the SDK installed.
+    """
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
+    async with streamablehttp_client(url) as (read_stream, write_stream, _):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            yield session
+
+
+async def call_tool_json(
+    session: Any,
+    name: str,
+    arguments: Optional[Dict[str, Any]] = None,
+) -> Any:
+    """Call an MCP tool and return its payload parsed as JSON.
+
+    Prefers `structuredContent` when the server populates it; falls back to the
+    first text content block. Raises `RuntimeError` if the tool reported an
+    error or produced no parseable payload.
+    """
+    result = await session.call_tool(name, arguments or {})
+
+    if getattr(result, "isError", False):
+        raise RuntimeError(f"MCP tool {name!r} returned isError=True: {result.content!r}")
+
+    structured = getattr(result, "structuredContent", None)
+    if structured is not None:
+        return structured
+
+    for block in result.content or []:
+        if getattr(block, "type", None) == "text":
+            text = getattr(block, "text", "")
+            return json.loads(text)
+
+    raise RuntimeError(f"MCP tool {name!r} returned no text or structured content")


### PR DESCRIPTION
Split MCP data access from LLM reasoning in the scanner's MITRE stage:
- Add shared/mcp_utils.py wrapping the public `mcp` SDK (streamable HTTP session + text/structuredContent parser).
- Rewrite agents/scanner/pipeline/mitre_mapper.py to cache every Enterprise technique once (paginated), shortlist candidates per finding in Python, and issue a single provider.structured_output() call per finding.

Removes AzureOpenAIChatClient and agent_framework._mcp imports from the scanner pipeline, so MITRE mapping now works identically under LLM_PROVIDER=azure and LLM_PROVIDER=claude. Smoke-tested end-to-end on both providers (0 mapping errors across 70 and 101 findings).